### PR TITLE
Validity Period Updates

### DIFF
--- a/HydrantIdProxy/src/HydrantIdProxy/RequestManager.cs
+++ b/HydrantIdProxy/src/HydrantIdProxy/RequestManager.cs
@@ -136,7 +136,7 @@ namespace Keyfactor.HydrantId
                         Csr = csr,
                         DnComponents = GetDnComponentsRequest(csr),
                         SubjectAltNames = GetSansRequest(san),
-                        Validity = GetValidity(productInfo.ProductParameters["Validity Period"],Convert.ToInt16(productInfo.ProductParameters["Validity Units"]))
+                        Validity = GetValidity(productInfo.ProductParameters["ValidityPeriod"],Convert.ToInt16(productInfo.ProductParameters["ValidityUnits"]))
                     };
                 }
 
@@ -145,7 +145,7 @@ namespace Keyfactor.HydrantId
                     Policy = policyId,
                     Csr = csr,
                     DnComponents = GetDnComponentsRequest(csr),
-                    Validity=GetValidity(productInfo.ProductParameters["Validity Period"], Convert.ToInt16(productInfo.ProductParameters["Validity Units"]))
+                    Validity=GetValidity(productInfo.ProductParameters["ValidityPeriod"], Convert.ToInt16(productInfo.ProductParameters["ValidityUnits"]))
                 };
             }
             catch (Exception e)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ HydrantId operates a PKI as a service platform for customers around the globe.  
 *** 
 # Getting Started
 ## Standard Gateway Installation
-To begin, you must have the CA Gateway Service 21.3.2 installed and operational before attempting to configure the HydrantId plugin. This integration was tested with Keyfactor 8.7.0.0.
+To begin, you must have the CA Gateway Service 21.3.2 installed and operational before attempting to configure the HydrantId plugin. This integration was tested with Keyfactor 9.3.0.0.
 To install the gateway follow these instructions.
 
 1) Gateway Server - run the installation .msi obtained from Keyfactor
@@ -150,7 +150,6 @@ the CA.  Without the imported configuration, the service will fail to start.
 3) Command Server - Run the CreateTemplate.ps1 file and choose option 1 to create the templates in active directory.
    *Note if you get errors the security is likely wrong and you will have to add the security manually according to Keyfactor standards* 
 4) Command Server - Use the Keyfactor Portal to Import the Templates created in Active Directory in step #3 above
-5) Command Server - Run the CreateTemplate.ps1 file and choose option 3 to create all the enrollment fields.  
    *Note You will have to override the default API Questions to the appropriate information.*
 
 ### Certificate Authority Installation

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -9,7 +9,7 @@
 *** 
 # Getting Started
 ## Standard Gateway Installation
-To begin, you must have the CA Gateway Service 21.3.2 installed and operational before attempting to configure the HydrantId plugin. This integration was tested with Keyfactor 8.7.0.0.
+To begin, you must have the CA Gateway Service 21.3.2 installed and operational before attempting to configure the HydrantId plugin. This integration was tested with Keyfactor 9.3.0.0.
 To install the gateway follow these instructions.
 
 1) Gateway Server - run the installation .msi obtained from Keyfactor
@@ -150,7 +150,6 @@ the CA.  Without the imported configuration, the service will fail to start.
 3) Command Server - Run the CreateTemplate.ps1 file and choose option 1 to create the templates in active directory.
    *Note if you get errors the security is likely wrong and you will have to add the security manually according to Keyfactor standards* 
 4) Command Server - Use the Keyfactor Portal to Import the Templates created in Active Directory in step #3 above
-5) Command Server - Run the CreateTemplate.ps1 file and choose option 3 to create all the enrollment fields.  
    *Note You will have to override the default API Questions to the appropriate information.*
 
 ### Certificate Authority Installation

--- a/SampleConfig.json
+++ b/SampleConfig.json
@@ -1,60 +1,72 @@
 {
-  "Security": {
-    "KEYFACTOR\\administrator": {
-      "READ": "Allow",
-      "ENROLL": "Allow",
-      "OFFICER": "Allow",
-      "ADMINISTRATOR": "Allow"
-    },
-    "KEYFACTOR\\SVC_AppPool": {
-      "READ": "Allow",
-      "ENROLL": "Allow",
-      "OFFICER": "Allow",
-      "ADMINISTRATOR": "Allow"
-    },
-    "KEYFACTOR\\SVC_TimerService": {
-      "READ": "Allow",
-      "ENROLL": "Allow",
-      "OFFICER": "Allow",
-      "ADMINISTRATOR": "Allow"
-    }
-  },
-  "CAConnection": {
-    "HydrantIdBaseUrl": "https://acm-stage.hydrantid.com",
-    "AuthId": "getAuthIdFromHydrant",
-    "AuthKey": "getAuthKeyFromHydrant",
-    "TemplateSync": "On"
-  },
-  "Templates": {
-    "AutoEnrollment - ECDSA": {
-      "ProductID": "AutoEnrollment - ECDSA",
-      "Parameters": {}
-    },
-    "AutoEnrollment - ECDSA - 7 Day": {
-      "ProductID": "AutoEnrollment - ECDSA - 7 Day",
-      "Parameters": {}
-    },
-    "AutoEnrollment - RSA": {
-      "ProductID": "AutoEnrollment - RSA",
-      "Parameters": {}
-    },
-    "AutoEnrollment - RSA - 7 Day": {
-      "ProductID": "AutoEnrollment - RSA - 7 Day",
-      "Parameters": {}
-    }
-  },
-  "CertificateManagers": null,
-  "GatewayRegistration": {
-    "LogicalName": "HydrantId",
-    "GatewayCertificate": {
-      "StoreName": "CA",
-      "StoreLocation": "LocalMachine",
-      "Thumbprint": "3c97cbb4491fc8d63d12b4890c28548164198edb"
-    }
-  },
-  "ServiceSettings": {
-    "ViewIdleMinutes": 1,
-    "FullScanPeriodHours": 1,
-    "PartialScanPeriodMinutes": 1
-  }
+	"Security": {
+		"KEYFACTOR\\administrator": {
+			"READ": "Allow",
+			"ENROLL": "Allow",
+			"OFFICER": "Allow",
+			"ADMINISTRATOR": "Allow"
+		},
+		"KEYFACTOR\\SVC_AppPool": {
+			"READ": "Allow",
+			"ENROLL": "Allow",
+			"OFFICER": "Allow",
+			"ADMINISTRATOR": "Allow"
+		},
+		"KEYFACTOR\\SVC_TimerService": {
+			"READ": "Allow",
+			"ENROLL": "Allow",
+			"OFFICER": "Allow",
+			"ADMINISTRATOR": "Allow"
+		}
+	},
+	"CAConnection": {
+		"HydrantIdBaseUrl": "https://acm-stage.hydrantid.com",
+		"AuthId": "getAuthIdFromHydrant",
+		"AuthKey": "getAuthKeyFromHydrant",
+		"TemplateSync": "On"
+	},
+	"Templates": {
+		"AutoEnrollment - ECDSA": {
+			"ProductID": "AutoEnrollment - ECDSA",
+			"Parameters": {
+				"ValidityPeriod": "Years",
+				"ValidityUnits": 1
+			}
+		},
+		"AutoEnrollment - ECDSA - 7 Day": {
+			"ProductID": "AutoEnrollment - ECDSA - 7 Day",
+			"Parameters": {
+				"ValidityPeriod": "Days",
+				"ValidityUnits": 7
+			}
+		},
+		"AutoEnrollment - RSA": {
+			"ProductID": "AutoEnrollment - RSA",
+			"Parameters": {
+				"ValidityPeriod": "Years",
+				"ValidityUnits": 1
+			}
+		},
+		"AutoEnrollment - RSA - 7 Day": {
+			"ProductID": "AutoEnrollment - RSA - 7 Day",
+			"Parameters": {
+				"ValidityPeriod": "Days",
+				"ValidityUnits": 7
+			}
+		}
+	},
+	"CertificateManagers": null,
+	"GatewayRegistration": {
+		"LogicalName": "HydrantId",
+		"GatewayCertificate": {
+			"StoreName": "CA",
+			"StoreLocation": "LocalMachine",
+			"Thumbprint": "3c97cbb4491fc8d63d12b4890c28548164198edb"
+		}
+	},
+	"ServiceSettings": {
+		"ViewIdleMinutes": 1,
+		"FullScanPeriodHours": 1,
+		"PartialScanPeriodMinutes": 1
+	}
 }

--- a/Templates/AutoEnrollment - RSA.json
+++ b/Templates/AutoEnrollment - RSA.json
@@ -10,26 +10,7 @@
   "KeyRetention": "AfterExpiration",
   "KeyRetentionDays": 55,
   "KeyArchival": false,
-  "EnrollmentFields": [
-    {
-      "Id": 2222971,
-      "Name": "Validity Period",
-      "Options": [
-        "Years",
-		"Days",
-		"Months"
-      ],
-      "DataType": 2
-    },
-    {
-      "Id": 2222972,
-      "Name": "Validity Units",
-      "Options": [
-        ""
-      ],
-      "DataType": 1
-    }
-  ],
+  "EnrollmentFields": [],
   "AllowedEnrollmentTypes": 7,
   "TemplateRegexes": [],
   "UseAllowedRequesters": false,


### PR DESCRIPTION
Added the validity period and validity units to the configuration JSON instead of being an enrollment parameter.  Advantages are that there are now no enrollment params for the user to enter and one click renewal/reissue will work because these do not need to be entered anymore.